### PR TITLE
fix(deps): update npm directory path to /app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   # Enable version updates for npm (JavaScript/TypeScript projects)
   # Includes both regular updates and security updates
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/app"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Fixes dependabot npm configuration to point to /app directory where package.json is located.