### PR TITLE
fix: add turbopack config for Next.js 16 compatibility

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   compiler: {
     styledComponents: true, // Enables styled-components support
   },
+  // Empty turbopack config acknowledges Next.js 16's default Turbopack usage
+  // Webpack config below won't apply in production builds with Turbopack
+  turbopack: {},
   // Optimize bundle to reduce unused JavaScript
   webpack: (config, { dev, isServer }) => {
     if (!dev && !isServer) {


### PR DESCRIPTION
Adds empty \	urbopack: {}\ config to acknowledge Next.js 16's default Turbopack usage.

The webpack config is retained but won't apply in production builds with Turbopack. Applications typically work fine under Turbopack with no configuration.

Closes #35