### PR TITLE
docs(pmo): Q2 2026 roadmap and tasks update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
+Last Updated: 2026-04-03
 
 ## 2025 Q4 (Completed)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last Updated: 2026-03-28
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## 2025 Q4 (Completed)
 
@@ -17,8 +17,10 @@ Last Updated: 2026-03-28
 ## 2026 Q2 (Planned)
 
 - [x] Add dedicated architecture and interface documentation for the arcade platform.
-- [ ] Revisit performance, responsiveness, and large-asset delivery after the release-path fixes land.
-- [ ] Verify accessibility and UX against the current live routes.
+- [ ] **Performance and large-asset delivery**: audit and improve game asset loading (audio, sprites, backgrounds); lazy-load non-critical assets; reduce time-to-first-playable.
+- [ ] **Responsiveness and mobile UX**: verify game routes on mobile viewports; fix any touch/input regressions; ensure Asteroid and other games are playable on phone/tablet.
+- [ ] **Accessibility audit**: run and resolve core a11y issues (keyboard navigation, ARIA for game controls, color contrast on HUD/scoreboard).
+- [ ] **UX verification pass**: walk through all live game routes as a first-time user; document any friction or broken states found.
 
 ## 2026 Q3 (Planned)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
+Last Updated: 2026-04-03
 
 ## Done
 
@@ -51,6 +51,11 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
   - Priority: P2
   - Problem: game UI (HUD, scoreboard, menus) lacks ARIA labels, keyboard navigation, and sufficient color contrast in several spots.
   - Acceptance Criteria: no critical or serious a11y violations per axe-core; game control descriptions are accessible; color contrast meets WCAG AA.
+
+- [ ] **[Q2] UX verification pass** — walk through all live game routes as a first-time user and document any friction or broken states found.
+  - Priority: P2
+  - Problem: no structured first-run walkthrough has been performed; hidden friction points and broken states may exist across routes that aren't caught by automated checks.
+  - Acceptance Criteria: all live game routes exercised end-to-end; any friction or broken states logged as follow-up issues; findings summarized in METRICS.md or a dedicated audit note.
 
 - [ ] Re-scope expansion work after platform issues are fixed.
   - Priority: P2

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-03-28
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## Done
 
@@ -36,6 +36,21 @@ Last Updated: 2026-03-28
 ## In Progress
 
 ## Todo
+
+- [ ] **[Q2] Performance audit and asset optimization** — identify and fix the largest asset/load-time bottlenecks across game routes.
+  - Priority: P1
+  - Problem: audio, sprites, and backgrounds are loaded eagerly on some routes; this hurts time-to-first-playable especially on mobile.
+  - Acceptance Criteria: each game route loads its primary interactive surface within 3s on a simulated mid-tier mobile connection; large assets are lazy-loaded; METRICS.md updated with measured values.
+
+- [ ] **[Q2] Mobile responsiveness and touch input** — verify all game routes work on phone/tablet viewports with touch input.
+  - Priority: P1
+  - Problem: games were built and tested primarily on desktop; touch controls and layout breakpoints have not been verified on real devices.
+  - Acceptance Criteria: Asteroid and at least two other games are fully playable on iOS Safari and Android Chrome; no layout overflow or control dead zones; documented in METRICS.md.
+
+- [ ] **[Q2] Accessibility pass** — resolve core a11y issues across game routes and the arcade homepage.
+  - Priority: P2
+  - Problem: game UI (HUD, scoreboard, menus) lacks ARIA labels, keyboard navigation, and sufficient color contrast in several spots.
+  - Acceptance Criteria: no critical or serious a11y violations per axe-core; game control descriptions are accessible; color contrast meets WCAG AA.
 
 - [ ] Re-scope expansion work after platform issues are fixed.
   - Priority: P2


### PR DESCRIPTION
## Summary

Updates ROADMAP.md and TASKS.md planning docs for 2026 Q2 priorities. Preserves PMO-first flow before implementation (DEV flow follows after merge). Scope is limited to markdown planning docs only.

## Changes

- Adds Q2 2026 priority work items to TASKS.md (performance, mobile UX, accessibility) with priorities, problem statements, and acceptance criteria.
- Expands Q2 roadmap bullets in ROADMAP.md into clearer, more actionable initiative descriptions.
- Fixes `Last Updated` format in both ROADMAP.md and TASKS.md to use date-only (removes branch suffix) for consistency with other project docs such as `ARCHITECTURE.md` and `API.md`.
- Adds `[Q2] UX verification pass` task to TASKS.md (priority P2, problem statement, acceptance criteria) to align with the corresponding Q2 bullet in ROADMAP.md.

## Testing

Planning-only changes (markdown docs). No build or test steps required.

- Verified `Last Updated` format is now consistent (date-only) across ROADMAP.md, TASKS.md, ARCHITECTURE.md, and API.md.
- Confirmed all four Q2 ROADMAP.md initiatives have a matching task entry in TASKS.md.

## Screenshots (optional)

N/A — documentation-only changes.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated (if needed)
- [ ] Linked to related issues / tasks
- [x] Follows project conventions