### PR TITLE
perf(home): lazy-load arcade audio asset fetch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
+Last Updated: 2026-04-03
 
 ## 2025 Q4 (Completed)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,6 +17,7 @@ Last Updated: 2026-04-03
 ## 2026 Q2 (Planned)
 
 - [x] Add dedicated architecture and interface documentation for the arcade platform.
+- [x] Defer homepage ambient-audio fetch/init until user interaction to reduce initial route load pressure.
 - [ ] **Performance and large-asset delivery**: audit and improve game asset loading (audio, sprites, backgrounds); lazy-load non-critical assets; reduce time-to-first-playable.
 - [ ] **Responsiveness and mobile UX**: verify game routes on mobile viewports; fix any touch/input regressions; ensure Asteroid and other games are playable on phone/tablet.
 - [ ] **Accessibility audit**: run and resolve core a11y issues (keyboard navigation, ARIA for game controls, color contrast on HUD/scoreboard).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last Updated: 2026-03-28
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## 2025 Q4 (Completed)
 
@@ -17,8 +17,10 @@ Last Updated: 2026-03-28
 ## 2026 Q2 (Planned)
 
 - [x] Add dedicated architecture and interface documentation for the arcade platform.
-- [ ] Revisit performance, responsiveness, and large-asset delivery after the release-path fixes land.
-- [ ] Verify accessibility and UX against the current live routes.
+- [ ] **Performance and large-asset delivery**: audit and improve game asset loading (audio, sprites, backgrounds); lazy-load non-critical assets; reduce time-to-first-playable.
+- [ ] **Responsiveness and mobile UX**: verify game routes on mobile viewports; fix any touch/input regressions; ensure Asteroid and other games are playable on phone/tablet.
+- [ ] **Accessibility audit**: run and resolve core a11y issues (keyboard navigation, ARIA for game controls, color contrast on HUD/scoreboard).
+- [ ] **UX verification pass**: walk through all live game routes as a first-time user; document any friction or broken states found.
 
 ## 2026 Q3 (Planned)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -32,6 +32,9 @@ Last Updated: 2026-04-03
   - Evidence: added `ARCHITECTURE.md` and `API.md` and linked both from `README.md`.
 - [x] Enable Docker-based test/coverage workflow (see README and METRICS.md)
 - [x] Enable Docker-based E2E test workflow (see README and METRICS.md)
+- [x] Defer homepage arcade audio asset loading until explicit user interaction.
+  - Completed: 2026-04-03
+  - Evidence: `app/_components/home/AudioController.tsx` now lazy-creates the audio element on unmute and sets `preload='none'`; verified by `app/tests/home/AudioController.test.jsx`.
 
 ## In Progress
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
+Last Updated: 2026-04-03
 
 ## Done
 
@@ -51,6 +51,11 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
   - Priority: P2
   - Problem: game UI (HUD, scoreboard, menus) lacks ARIA labels, keyboard navigation, and sufficient color contrast in several spots.
   - Acceptance Criteria: no critical or serious a11y violations per axe-core; game control descriptions are accessible; color contrast meets WCAG AA.
+
+- [ ] **[Q2] UX verification pass** — walk through all live game routes as a first-time user and document any friction or broken states found.
+  - Priority: P2
+  - Problem: no structured first-run walkthrough has been performed; hidden friction points and broken states may exist across routes that aren't caught by automated checks.
+  - Acceptance Criteria: all live game routes exercised end-to-end; any friction or broken states logged as follow-up issues; findings summarized in METRICS.md or a dedicated audit note.
 
 - [ ] Re-scope expansion work after platform issues are fixed.
   - Priority: P2

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-03-28
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## Done
 
@@ -36,6 +36,21 @@ Last Updated: 2026-03-28
 ## In Progress
 
 ## Todo
+
+- [ ] **[Q2] Performance audit and asset optimization** — identify and fix the largest asset/load-time bottlenecks across game routes.
+  - Priority: P1
+  - Problem: audio, sprites, and backgrounds are loaded eagerly on some routes; this hurts time-to-first-playable especially on mobile.
+  - Acceptance Criteria: each game route loads its primary interactive surface within 3s on a simulated mid-tier mobile connection; large assets are lazy-loaded; METRICS.md updated with measured values.
+
+- [ ] **[Q2] Mobile responsiveness and touch input** — verify all game routes work on phone/tablet viewports with touch input.
+  - Priority: P1
+  - Problem: games were built and tested primarily on desktop; touch controls and layout breakpoints have not been verified on real devices.
+  - Acceptance Criteria: Asteroid and at least two other games are fully playable on iOS Safari and Android Chrome; no layout overflow or control dead zones; documented in METRICS.md.
+
+- [ ] **[Q2] Accessibility pass** — resolve core a11y issues across game routes and the arcade homepage.
+  - Priority: P2
+  - Problem: game UI (HUD, scoreboard, menus) lacks ARIA labels, keyboard navigation, and sufficient color contrast in several spots.
+  - Acceptance Criteria: no critical or serious a11y violations per axe-core; game control descriptions are accessible; color contrast meets WCAG AA.
 
 - [ ] Re-scope expansion work after platform issues are fixed.
   - Priority: P2

--- a/app/_components/home/AudioController.tsx
+++ b/app/_components/home/AudioController.tsx
@@ -36,22 +36,6 @@ export const AudioController = () => {
     const audioRef = useRef<HTMLAudioElement | null>(null);
 
     useEffect(() => {
-        // Create audio element with error handling
-        // Note: Audio file path is hardcoded. File existence is verified during build.
-        // If file is missing, error handler logs gracefully without breaking user experience.
-        try {
-            audioRef.current = new Audio('/sounds/arcade.mp3');
-            audioRef.current.loop = true;
-            audioRef.current.volume = 0.3;
-
-            // Handle audio loading errors
-            audioRef.current.addEventListener('error', (e) => {
-                console.error('Failed to load audio file:', e);
-            });
-        } catch (error) {
-            console.error('Failed to create Audio element:', error);
-        }
-
         return () => {
             if (audioRef.current) {
                 audioRef.current.pause();
@@ -60,19 +44,45 @@ export const AudioController = () => {
         };
     }, []);
 
-    const toggleMute = () => {
+    const getOrCreateAudio = () => {
         if (audioRef.current) {
-            if (muted) {
-                audioRef.current.play().catch(e => {
-                    console.error(
-                        `Audio playback failed: ${e?.name ? e.name + ': ' : ''}${e?.message ?? e}. This may be due to browser autoplay restrictions, unsupported audio format, or lack of user interaction.`
-                    );
-                });
-            } else {
-                audioRef.current.pause();
-            }
-            setMuted(!muted);
+            return audioRef.current;
         }
+
+        // Lazy-create and lazy-fetch the audio asset only after explicit user intent.
+        try {
+            const audio = new Audio('/sounds/arcade.mp3');
+            audio.loop = true;
+            audio.volume = 0.3;
+            audio.preload = 'none';
+            audio.addEventListener('error', (e) => {
+                console.error('Failed to load audio file:', e);
+            });
+            audioRef.current = audio;
+            return audio;
+        } catch (error) {
+            console.error('Failed to create Audio element:', error);
+            return null;
+        }
+    };
+
+    const toggleMute = () => {
+        const audio = getOrCreateAudio();
+        if (!audio) {
+            return;
+        }
+
+        if (muted) {
+            audio.play().catch(e => {
+                console.error(
+                    `Audio playback failed: ${e?.name ? e.name + ': ' : ''}${e?.message ?? e}. This may be due to browser autoplay restrictions, unsupported audio format, or lack of user interaction.`
+                );
+            });
+        } else {
+            audio.pause();
+        }
+
+        setMuted(!muted);
     };
 
     return (

--- a/app/tests/home/AudioController.test.jsx
+++ b/app/tests/home/AudioController.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AudioController } from '@/_components/home/AudioController';
+
+describe('AudioController lazy audio loading', () => {
+  const OriginalAudio = global.Audio;
+
+  const createAudioMock = () => {
+    const mockAudio = {
+      loop: false,
+      volume: 1,
+      preload: 'auto',
+      addEventListener: jest.fn(),
+      play: jest.fn(() => Promise.resolve()),
+      pause: jest.fn(),
+    };
+
+    global.Audio = jest.fn(() => mockAudio);
+    return mockAudio;
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.Audio = OriginalAudio;
+  });
+
+  it('does not create audio on initial render and creates it only after unmute click', async () => {
+    const user = userEvent.setup();
+    const mockAudio = createAudioMock();
+
+    render(<AudioController />);
+
+    expect(global.Audio).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTitle('Unmute Music'));
+
+    expect(global.Audio).toHaveBeenCalledTimes(1);
+    expect(mockAudio.preload).toBe('none');
+    expect(mockAudio.play).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTitle('Mute Music'));
+
+    expect(global.Audio).toHaveBeenCalledTimes(1);
+    expect(mockAudio.pause).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/HANDOFF-home-audio-lazy-load-20260403.md
+++ b/docs/HANDOFF-home-audio-lazy-load-20260403.md
@@ -1,0 +1,22 @@
+# Handoff: Homepage Audio Lazy Load (2026-04-03)
+
+## Summary
+Implemented a performance-focused homepage optimization to avoid eager arcade BGM loading before the user opts in.
+
+## What Changed
+- Updated `app/_components/home/AudioController.tsx` so the `Audio` element is not created on mount.
+- Added lazy creation via `getOrCreateAudio()` on first unmute interaction.
+- Set `audio.preload = 'none'` to avoid prefetching the audio file during initial page load.
+- Preserved mute/unmute behavior and existing error handling.
+
+## Validation
+- Docker-focused unit test:
+  - `docker build --target test-unit -t games-test .`
+  - `docker run --rm games-test npm run test:ci -- tests/home/AudioController.test.jsx`
+- Result: 1 passed, 0 failed.
+
+## Files
+- `app/_components/home/AudioController.tsx`
+- `app/tests/home/AudioController.test.jsx`
+- `TASKS.md`
+- `ROADMAP.md`


### PR DESCRIPTION
## Summary
- defer homepage arcade music initialization so Audio is created only when the user explicitly unmutes
- set preload='none' for arcade BGM to avoid eager initial-route media fetch
- add focused unit test coverage for lazy creation and mute/unmute reuse behavior
- update roadmap/tasks status and add handoff notes

## Testing
- docker build --target test-unit -t games-test .
- docker run --rm games-test npm run test:ci -- tests/home/AudioController.test.jsx

## PMO Dependency Note
- The PMO planning branch pmo/q2-2026-planning is not currently available as a remote base ref in this repository, so this PR targets main while keeping PMO-aligned planning updates in TASKS/ROADMAP.