### PR TITLE
chore: rename workflow to "ci"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: Games CI/CD Pipeline
+name: ci
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Renames the `Games CI/CD Pipeline` workflow to `ci` to match the convention used in other repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)